### PR TITLE
[FIX] : 🐛 타이틀 문구를 기존의 위치보다 상단으로 조정

### DIFF
--- a/HWIBAL/Views/HomeView/HomeView.swift
+++ b/HWIBAL/Views/HomeView/HomeView.swift
@@ -71,11 +71,11 @@ final class HomeView: UIView, RootView {
     private func setupConstraints() {
         if let safeAreaLayoutGuide = viewController?.view.safeAreaLayoutGuide {
             titleLabel1.snp.makeConstraints { make in
-                make.top.equalTo(safeAreaLayoutGuide).offset(10)
+                make.top.equalTo(safeAreaLayoutGuide)
                 make.left.equalTo(40)
             }
             titleLabel2.snp.makeConstraints { make in
-                make.top.equalTo(titleLabel1.snp.bottom).offset(0)
+                make.top.equalTo(titleLabel1.snp.bottom)
                 make.left.equalTo(40)
             }
             hwibariImage.snp.makeConstraints { make in


### PR DESCRIPTION
![simulator_screenshot_C3033ACD-C839-480B-B5A1-7D223B11CD0B](https://github.com/hidaehyunlee/HWIBAL/assets/139306158/1baca879-7b6d-44e3-94b6-8ecc773498b0)

![simulator_screenshot_1FF219E3-E493-49E6-9E70-5F961D5FE6CE](https://github.com/hidaehyunlee/HWIBAL/assets/139306158/2fcfea43-90f3-430a-b698-9f7ca10b657a)
