### PR TITLE
[FEAT]: 👍 감정쓰레기 개별삭제 구현 및 DetailView Issue 해결

### DIFF
--- a/HWIBAL/Controllers/DetailViewController.swift
+++ b/HWIBAL/Controllers/DetailViewController.swift
@@ -25,10 +25,10 @@ final class DetailViewController: RootViewController<DetailView> {
 
         rootView.collectionView.delegate = self
         rootView.collectionView.dataSource = self
-        
+
         userEmotionTrashes = EmotionTrashService.shared.fetchTotalEmotionTrashes(signedInUser)
         rootView.totalPage = userEmotionTrashes.count
-        
+
         bindDetailViewEvents()
     }
 
@@ -53,10 +53,6 @@ final class DetailViewController: RootViewController<DetailView> {
 //            print("Error creating audio player: \(error)")
 //        }
 //    }
-
-    @objc func buttonTapped() {
-        print("휘발 되었습니다.")
-    }
 
     @objc func goToFirstButtonTapped() {
         rootView.collectionView.setContentOffset(CGPoint(x: -DetailView.CarouselConst.insetX, y: 0), animated: true)
@@ -88,6 +84,16 @@ final class DetailViewController: RootViewController<DetailView> {
             rootView.playPauseButton.setBackgroundImage(UIImage(named: "pause"), for: .normal)
         }
     }
+
+    @objc func deleteButtonTapped(sender: UIButton) {
+        let index = sender.tag
+        let cellId = userEmotionTrashes[index].id
+
+        AlertManager.shared.showAlert(on: self, title: "아, 휘발 🔥", message: "이 감정쓰레기를 삭제하시겠습니까?") { _ in
+            EmotionTrashService.shared.deleteEmotionTrash(self.signedInUser, cellId!)
+            self.navigationController?.popViewController(animated: true)
+        }
+    }
 }
 
 extension DetailViewController: UICollectionViewDataSource {
@@ -113,15 +119,18 @@ extension DetailViewController: UICollectionViewDataSource {
             cell.showImageButton.isHidden = true
         }
 
-        if let audioFilePath = data.recording?.filePath {
-            // let audioFileName = URL(fileURLWithPath: audioFilePath)
-            // configureAudioPlayer(for: indexPath, withFileName: audioFilePath)
+        // if let audioFilePath = data.recording?.filePath {
+        // let audioFileName = URL(fileURLWithPath: audioFilePath)
+        // configureAudioPlayer(for: indexPath, withFileName: audioFilePath)
 
-            rootView.playPauseButton.isHidden = false
-        } else {}
+        // rootView.playPauseButton.isHidden = false
+        // } else {}
 
         cell.daysAgoLabel.text = getDaysAgo(startDate: Date(), endDate: data.timestamp ?? Date()) // 몇일전인지 구함
         cell.textContentLabel.text = data.text
+
+        rootView.deleteButton.addTarget(self, action: #selector(deleteButtonTapped), for: .touchUpInside)
+        rootView.deleteButton.tag = indexPath.item
 
         cell.layer.cornerRadius = 12
         cell.layer.masksToBounds = true
@@ -151,8 +160,8 @@ extension DetailViewController: UICollectionViewDataSource {
 
 extension DetailViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let cellId = userEmotionTrashes[indexPath.item].id
-        print("현재 cell id: \(cellId)") // 추후 삭제 구현시 확인을 위해 남겨둠
+        // let cellId = userEmotionTrashes[indexPath.item].id
+        // print("현재 cell id: \(cellId)") // 추후 삭제 구현시 확인을 위해 남겨둠
     }
 
     // 스크롤이 멈추면 호출되며, 스크롤이 셀의 중앙에 멈추도록 함

--- a/HWIBAL/Controllers/DetailViewController.swift
+++ b/HWIBAL/Controllers/DetailViewController.swift
@@ -87,7 +87,7 @@ final class DetailViewController: RootViewController<DetailView> {
         let index = sender.tag
         let cellId = userEmotionTrashes[index].id
 
-        AlertManager.shared.showAlert(on: self, title: "아, 휘발 🔥", message: "이 감정쓰레기를 삭제하시겠습니까?") { _ in
+        AlertManager.shared.showAlert(on: self, title: "감정쓰레기 삭제", message: "당신의 이 감정을 불태워 드릴게요.") { _ in
             EmotionTrashService.shared.deleteEmotionTrash(self.signedInUser, cellId!)
             self.navigationController?.popViewController(animated: true)
             NotificationCenter.default.post(name: NSNotification.Name("EmotionTrashUpdate"), object: nil)

--- a/HWIBAL/Controllers/DetailViewController.swift
+++ b/HWIBAL/Controllers/DetailViewController.swift
@@ -21,8 +21,6 @@ final class DetailViewController: RootViewController<DetailView> {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .white
-
         rootView.collectionView.delegate = self
         rootView.collectionView.dataSource = self
 
@@ -92,6 +90,7 @@ final class DetailViewController: RootViewController<DetailView> {
         AlertManager.shared.showAlert(on: self, title: "아, 휘발 🔥", message: "이 감정쓰레기를 삭제하시겠습니까?") { _ in
             EmotionTrashService.shared.deleteEmotionTrash(self.signedInUser, cellId!)
             self.navigationController?.popViewController(animated: true)
+            NotificationCenter.default.post(name: NSNotification.Name("EmotionTrashUpdate"), object: nil)
         }
     }
 }

--- a/HWIBAL/Views/DetailView/DetailView.swift
+++ b/HWIBAL/Views/DetailView/DetailView.swift
@@ -14,13 +14,13 @@ final class DetailView: UIView, RootView {
         let button = UIButton()
 
         button.setTitle(" 맨 처음으로", for: .normal)
-        button.setTitleColor(.black, for: .normal)
+        button.setTitleColor(.label, for: .normal)
         button.titleLabel?.font = FontGuide.size14Bold
 
         if let image = UIImage(named: "<-") {
-            let blackImage = image.withRenderingMode(.alwaysTemplate)
-            button.setImage(blackImage, for: .normal)
-            button.tintColor = UIColor.black
+            let colorImage = image.withRenderingMode(.alwaysTemplate)
+            button.setImage(colorImage, for: .normal)
+            button.tintColor = UIColor.label
         }
         button.semanticContentAttribute = .forceLeftToRight
 
@@ -35,7 +35,7 @@ final class DetailView: UIView, RootView {
 
             let attributedString = NSMutableAttributedString(string: currentPageText, attributes: [
                 .font: FontGuide.size16Bold,
-                .foregroundColor: UIColor.black
+                .foregroundColor: UIColor.label
             ])
 
             let totalPageAttributedString = NSAttributedString(string: totalPageText, attributes: [
@@ -154,7 +154,7 @@ final class DetailView: UIView, RootView {
 
         let attributedString = NSMutableAttributedString(string: currentPageText, attributes: [
             .font: FontGuide.size16Bold,
-            .foregroundColor: UIColor.black
+            .foregroundColor: UIColor.label
         ])
 
         let totalPageAttributedString = NSAttributedString(string: totalPageText, attributes: [

--- a/HWIBAL/Views/DetailView/DetailView.swift
+++ b/HWIBAL/Views/DetailView/DetailView.swift
@@ -101,7 +101,7 @@ final class DetailView: UIView, RootView {
         return button
     }()
 
-    private lazy var deleteButton = MainButton(type: .delete)
+    lazy var deleteButton = MainButton(type: .delete)
 
     func initializeUI() {
         backgroundColor = .systemBackground

--- a/HWIBAL/Views/DetailView/EmotionTrashCell.swift
+++ b/HWIBAL/Views/DetailView/EmotionTrashCell.swift
@@ -11,7 +11,7 @@ import UIKit
 class EmotionTrashCell: UICollectionViewCell, RootView {
     static let identifier = "EmotionTrashCell"
 
-     lazy var showImageButton: UIButton = {
+    lazy var showImageButton: UIButton = {
         let button = UIButton()
 
         button.setTitle("사진보기", for: .normal)
@@ -35,16 +35,17 @@ class EmotionTrashCell: UICollectionViewCell, RootView {
         return label
     }()
 
-    lazy var textContentLabel: UILabel = {
-        let label = UILabel()
+    lazy var textContentLabel: UITextView = {
+        let textView = UITextView()
 
-        label.text = ""
-        label.font = FontGuide.size14
-        label.textColor = .white
-        label.numberOfLines = 0
-        label.sizeToFit()
+        textView.text = ""
+        textView.backgroundColor = ColorGuide.main
+        textView.font = FontGuide.size14
+        textView.textColor = .white
+        textView.isEditable = false
+        textView.isSelectable = false
 
-        return label
+        return textView
     }()
 
     var emotionTrashBackView: EmotionTrashBackView = .init()
@@ -76,10 +77,9 @@ class EmotionTrashCell: UICollectionViewCell, RootView {
         }
 
         textContentLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(20)
-            make.left.equalToSuperview().offset(20)
+            make.top.left.equalToSuperview().offset(20)
             make.right.equalToSuperview().offset(-20)
-            // bottom을 잡으면 label text가 아래로 내려옴. 어차피 글자수 제한 있으니 동적으로 안만들고 constraint 안잡아둘게요.
+            make.bottom.equalTo(showImageButton.snp.topMargin).offset(-20)
         }
     }
 


### PR DESCRIPTION
### 1. 감정쓰레기 개별삭제 [issue #33]
- Alert로 한번 확인 후 홈뷰로 이동한 뒤 삭제됩니다.
- 공용컴포넌트인 AlertManager를 사용했습니다.

### 2. TextContentLabel을 UITextView로 수정 [issue #37]
- 스크롤 가능하게 해서 텍스트를 짤리지 않고 볼 수 있도록 했습니다.

### 3. 다크모드시 안보이는 컴포넌트 색상 수정 [issue #41]
<img width="300" alt="image" src="https://github.com/hidaehyunlee/HWIBAL/assets/37580034/deb93ff0-147b-4dce-a26e-5f48846922e5">

### 문제점
- AlertManager에서 messageString 색상이랑 OK 문구를 바꿔야하지 않을까 싶습니다!
- ~삭제 후 HomeView로 이동하면 하나 삭제된 emotionCount 가 바로 적용이 안되는데, HomeView에서 emotionCount를 업데이트하도록 해야 할 것 같습니다. 뷰가 다시 표시될 때마다 새로 계산한 emotionCount를 표시해주는 식으로 해야할 것 같은데 제 코드가 아니라서 수정하진 않았습니다!~
  - NotificationCenter.default.post(name: NSNotification.Name("EmotionTrashUpdate"), object: nil) 추가로 해결했습니다.