### PR TITLE
[FIX] : 🐛 공통컴포넌트/MainButton 가로 사이즈 변경 issue #40

### DIFF
--- a/HWIBAL/Views/Shared/MainButton.swift
+++ b/HWIBAL/Views/Shared/MainButton.swift
@@ -24,7 +24,7 @@ class MainButton: UIButton {
         layer.borderColor = customButtonType.borderColor.cgColor
         layer.borderWidth = customButtonType.borderWidth
         snp.makeConstraints { make in
-            make.width.equalTo(333)
+            make.width.equalTo(345)
             make.height.equalTo(56)
         }
     }


### PR DESCRIPTION
### 1. 공통컴포넌트/MainButton 가로 사이즈 변경 issue #40 

```swift
snp.makeConstraints { make in
    make.width.equalTo(345)
    make.height.equalTo(56)
}
```

- 피그마 규격을 기준으로 333에서 345로 수정하였습니다.
- 나중에 여러기기에 대응하려면 가로사이즈를 fix하기보다, 해당 컴포넌트를 사용하는 코드에서 leading, trailing으로 레이아웃을 잡는게 더 현명해보입니다.

<br>

[적용 이미지] - Detail Page
<img src="https://github.com/hidaehyunlee/HWIBAL/assets/53863005/68902f27-b3b0-4bff-b0b0-83d933480cb9" width=300>