### PR TITLE
[FIX] : 🐛 Report Page 맨위로 버튼 클릭 시 페이지 카운팅 적용 Issue #39

### DIFF
--- a/HWIBAL/Controllers/ReportViewController.swift
+++ b/HWIBAL/Controllers/ReportViewController.swift
@@ -39,6 +39,9 @@ private extension ReportViewController {
     
     @objc func goToFirstButtonTapped() {
         rootView.collectionView.setContentOffset(CGPoint(x: 0, y: 0), animated: true)
+        DispatchQueue.main.async { [weak self] in
+            self?.rootView.updateNumberOfPageLabel(1)
+        }
     }
 }
 

--- a/HWIBAL/Views/ReportView/ReportView.swift
+++ b/HWIBAL/Views/ReportView/ReportView.swift
@@ -69,7 +69,6 @@ final class ReportView: UIView, RootView {
             let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
             let section = NSCollectionLayoutSection(group: group)
             section.orthogonalScrollingBehavior = .none
-//            section.interGroupSpacing = 65
                 
             return section
         }


### PR DESCRIPTION
### 1. [Report] 맨 위로 버튼 클릭 시 페이지 카운팅 적용 안됨 이슈 해결 issue #39 
* 버튼 클릭 시 goToFirstButtonTapped 함수에 페이지 카운트 업데이트 실행 함수 추가
```swift
@objc func goToFirstButtonTapped() {
    rootView.collectionView.setContentOffset(CGPoint(x: 0, y: 0), animated: true)
    DispatchQueue.main.async { [weak self] in
        self?.rootView.updateNumberOfPageLabel(1)
    }
}
```

[적용화면]
![Simulator Screen Recording - iPhone 14 Pro - 2023-10-30 at 11 08 47](https://github.com/hidaehyunlee/HWIBAL/assets/53863005/f9b74b21-5aba-4744-9355-c253738ae541)
