### PR TITLE
[FIX] : 🐛 MyPage 타이틀 짤리는 문제 해결 및 테이블 뷰 스크롤 false 처리 Issue #71

### DIFF
--- a/HWIBAL/Views/MyPageView/MyPageView.swift
+++ b/HWIBAL/Views/MyPageView/MyPageView.swift
@@ -24,9 +24,6 @@ final class MyPageView: UIView, RootView {
         label.textColor = .white
         label.textAlignment = .left
         label.numberOfLines = 2
-        label.snp.makeConstraints { make in
-            make.height.equalTo(60)
-        }
         return label
     }()
     
@@ -74,6 +71,7 @@ final class MyPageView: UIView, RootView {
     
     let tableView: UITableView = {
         let tableView = UITableView()
+        tableView.isScrollEnabled = false
         tableView.register(MyPageCustomCell.self, forCellReuseIdentifier: MyPageCustomCell.identifier)
         return tableView
     }()


### PR DESCRIPTION
* MyPage 리포트 요약 타이틀 짤리는 문제 해결
* 테이블 뷰 `isScrollEnabled` false 처리
[실기기 테스트 캡쳐본]
<img src="https://github.com/hidaehyunlee/HWIBAL/assets/53863005/47ecad0a-8dcf-4937-acc0-6f9e2aa3bdf0" width=300>
