### PR TITLE
[FIX] : 🐛 Report 오토레이아웃 충돌 해결 Issue #72 #74

### DIFF
--- a/HWIBAL/Controllers/ReportViewController.swift
+++ b/HWIBAL/Controllers/ReportViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SnapKit
 
 final class ReportViewController: RootViewController<ReportView> {
     private var ReportPageItems: [ReportPage] = []
@@ -21,7 +22,6 @@ final class ReportViewController: RootViewController<ReportView> {
             emptyView.snp.makeConstraints { make in
                 make.edges.equalToSuperview()
             }
-            
             emptyView.closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
         } else {
             initializeUI()

--- a/HWIBAL/Views/ReportView/ReportDayOfTheWeekCell.swift
+++ b/HWIBAL/Views/ReportView/ReportDayOfTheWeekCell.swift
@@ -299,21 +299,20 @@ class ReportDayOfTheWeekCell: UICollectionViewCell {
         rankTitle.snp.makeConstraints { make in
             make.top.leading.equalToSuperview()
         }
-        
+
         rankView.addSubview(seperateLineView)
         seperateLineView.snp.makeConstraints { make in
             make.height.equalTo(1)
             make.top.equalTo(rankTitle.snp.bottom).offset(10)
             make.leading.trailing.equalToSuperview()
-            make.centerX.equalToSuperview()
         }
-        
+
         rankView.addSubview(rank)
         rank.snp.makeConstraints { make in
             make.top.equalTo(seperateLineView.snp.bottom).offset(13)
             make.leading.trailing.bottom.equalToSuperview()
         }
-        
+
         view.addSubview(daysOfWeekView)
         daysOfWeekView.snp.makeConstraints { make in
             make.top.equalTo(subTitle.snp.bottom)

--- a/HWIBAL/Views/ReportView/ReportDayOfTheWeekCell.swift
+++ b/HWIBAL/Views/ReportView/ReportDayOfTheWeekCell.swift
@@ -28,6 +28,7 @@ class ReportDayOfTheWeekCell: UICollectionViewCell {
         label.textColor = .black
         label.textAlignment = .left
         label.numberOfLines = 2
+        label.adjustsFontSizeToFitWidth = true
         return label
     }()
     
@@ -36,7 +37,7 @@ class ReportDayOfTheWeekCell: UICollectionViewCell {
         label.font = FontGuide.size14
         label.textColor = .black
         label.textAlignment = .left
-        label.numberOfLines = 2
+        label.adjustsFontSizeToFitWidth = true
         return label
     }()
     
@@ -76,10 +77,6 @@ class ReportDayOfTheWeekCell: UICollectionViewCell {
     private let seperateLineView: UIView = {
         let view = UIView()
         view.backgroundColor = .black
-        view.snp.makeConstraints { make in
-            make.width.equalTo(295)
-            make.height.equalTo(1)
-        }
         return view
     }()
     
@@ -304,7 +301,9 @@ class ReportDayOfTheWeekCell: UICollectionViewCell {
         
         rankView.addSubview(seperateLineView)
         seperateLineView.snp.makeConstraints { make in
+            make.height.equalTo(1)
             make.top.equalTo(rankTitle.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview()
             make.centerX.equalToSuperview()
         }
         

--- a/HWIBAL/Views/ReportView/ReportDayOfTheWeekCell.swift
+++ b/HWIBAL/Views/ReportView/ReportDayOfTheWeekCell.swift
@@ -51,6 +51,12 @@ class ReportDayOfTheWeekCell: UICollectionViewCell {
         return label
     }()
     
+    private let daysOfWeekView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
+    
     private lazy var daysOfWeekStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
@@ -280,17 +286,12 @@ class ReportDayOfTheWeekCell: UICollectionViewCell {
             make.leading.equalToSuperview().offset(25)
         }
         
-        view.addSubview(daysOfWeekStackView)
-        daysOfWeekStackView.snp.makeConstraints { make in
-            make.top.equalTo(subTitle.snp.bottom).offset(84)
-            make.leading.equalToSuperview().offset(25)
-        }
-        
         view.addSubview(rankView)
         rankView.snp.makeConstraints { make in
-            make.width.equalTo(295)
             make.height.equalTo(111)
             make.centerX.equalToSuperview()
+            make.leading.equalToSuperview().offset(25)
+            make.trailing.equalToSuperview().offset(-25)
             make.bottom.equalToSuperview().offset(-40)
         }
         
@@ -311,6 +312,20 @@ class ReportDayOfTheWeekCell: UICollectionViewCell {
         rank.snp.makeConstraints { make in
             make.top.equalTo(seperateLineView.snp.bottom).offset(13)
             make.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        view.addSubview(daysOfWeekView)
+        daysOfWeekView.snp.makeConstraints { make in
+            make.top.equalTo(subTitle.snp.bottom)
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(rankView.snp.top)
+        }
+        
+        daysOfWeekView.addSubview(daysOfWeekStackView)
+        daysOfWeekStackView.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().offset(25)
+            make.trailing.equalToSuperview().offset(-25)
         }
     }
 }

--- a/HWIBAL/Views/ReportView/ReportDayOfTheWeekCell.swift
+++ b/HWIBAL/Views/ReportView/ReportDayOfTheWeekCell.swift
@@ -41,7 +41,7 @@ class ReportDayOfTheWeekCell: UICollectionViewCell {
         return label
     }()
     
-    let Largecircle: UILabel = {
+    let largeCircle: UILabel = {
         let label = UILabel()
         label.backgroundColor = ColorGuide.main
         label.font = FontGuide.size64Bold
@@ -227,8 +227,8 @@ class ReportDayOfTheWeekCell: UICollectionViewCell {
             let isMaxDay = day == maxDay
             let circleLabel: UILabel
             if isMaxDay {
-                circleLabel = Largecircle
-                let diameter = UIScreen.main.bounds.width - 278 // 셀 마진 24, 컨텐츠 마진 25, 작은 circle 지름30
+                circleLabel = largeCircle
+                let diameter = UIScreen.main.bounds.width - 278 // 셀 마진 24, 컨텐츠 마진 25, 작은 circle 지름 30
                 circleLabel.layer.cornerRadius = diameter/2
                 circleLabel.snp.makeConstraints { make in
                     make.width.height.equalTo(diameter)

--- a/HWIBAL/Views/ReportView/ReportDayOfTheWeekCell.swift
+++ b/HWIBAL/Views/ReportView/ReportDayOfTheWeekCell.swift
@@ -11,9 +11,10 @@ import DGCharts
 
 class ReportDayOfTheWeekCell: UICollectionViewCell {
     static let identifier = "dayOfTheWeekCell"
-    var daysOfWeekCount = ReportService.shared.calculateDaysOfWeekCount()
-    var maxDay = ""
-    var maxCount = 0
+    private var daysOfWeekCount = ReportService.shared.calculateDaysOfWeekCount()
+    private var maxDay = ""
+    private var maxCount = 0
+    private var chartGenerated = false
     
     private let view: UIView = {
         let view = UIView()
@@ -199,7 +200,10 @@ class ReportDayOfTheWeekCell: UICollectionViewCell {
         subTitle.text = "다른 요일보다 평균 감정쓰레기 개수가 많아요"
         
         // MARK: - Day of The Week
-        generateChartForDayOfWeek()
+        if !chartGenerated {
+            generateChartForDayOfWeek()
+            chartGenerated = true
+        }
         
         // MARK: - Rank
         let sortedDaysOfWeekCount = daysOfWeekCount.sorted { $0.value > $1.value }

--- a/HWIBAL/Views/ReportView/ReportSummaryCell.swift
+++ b/HWIBAL/Views/ReportView/ReportSummaryCell.swift
@@ -57,7 +57,7 @@ class ReportSummaryCell: UICollectionViewCell {
         chartView.rightAxis.enabled = false
         chartView.legend.enabled = false
         chartView.animate(yAxisDuration: 2, easingOption: .easeInBack)
-        chartView.setViewPortOffsets(left: 10, top: 15, right: 10, bottom: 25)
+        chartView.setViewPortOffsets(left: 10, top: 20, right: 10, bottom: 25)
         return chartView
     }()
     

--- a/HWIBAL/Views/ReportView/ReportSummaryCell.swift
+++ b/HWIBAL/Views/ReportView/ReportSummaryCell.swift
@@ -26,9 +26,7 @@ class ReportSummaryCell: UICollectionViewCell {
         label.textColor = .black
         label.textAlignment = .left
         label.numberOfLines = 2
-        label.snp.makeConstraints { make in
-            make.width.equalTo(180)
-        }
+        label.adjustsFontSizeToFitWidth = true
         return label
     }()
     
@@ -37,10 +35,7 @@ class ReportSummaryCell: UICollectionViewCell {
         label.font = FontGuide.size14
         label.textColor = .black
         label.textAlignment = .left
-        label.numberOfLines = 2
-        label.snp.makeConstraints { make in
-            make.width.equalTo(250)
-        }
+        label.adjustsFontSizeToFitWidth = true
         return label
     }()
     
@@ -62,9 +57,7 @@ class ReportSummaryCell: UICollectionViewCell {
         chartView.rightAxis.enabled = false
         chartView.legend.enabled = false
         chartView.animate(yAxisDuration: 2, easingOption: .easeInBack)
-        chartView.snp.makeConstraints { make in
-            make.width.equalTo(295)
-        }
+        chartView.setViewPortOffsets(left: 10, top: 15, right: 10, bottom: 25)
         return chartView
     }()
     
@@ -74,9 +67,7 @@ class ReportSummaryCell: UICollectionViewCell {
         label.font = FontGuide.size14
         label.textColor = ColorGuide.textHint
         label.textAlignment = .right
-        label.snp.makeConstraints { make in
-            make.width.equalTo(50)
-        }
+        label.adjustsFontSizeToFitWidth = true
         return label
     }()
    
@@ -140,6 +131,7 @@ class ReportSummaryCell: UICollectionViewCell {
         
         view.addSubview(chartView)
         chartView.snp.makeConstraints { make in
+            make.width.equalTo(295)
             make.top.equalTo(subTitle.snp.bottom).offset(60)
             make.bottom.equalToSuperview().offset(-40)
             make.centerX.equalToSuperview()

--- a/HWIBAL/Views/ReportView/ReportTimeZoneCell.swift
+++ b/HWIBAL/Views/ReportView/ReportTimeZoneCell.swift
@@ -41,6 +41,18 @@ class ReportTimeZoneCell: UICollectionViewCell {
         return label
     }()
     
+    private let subView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
+    
+    private let timeZoneView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
+    
     lazy var fromTimeUnit: UILabel = {
         let label = UILabel()
         label.font = FontGuide.size14Bold
@@ -90,6 +102,14 @@ class ReportTimeZoneCell: UICollectionViewCell {
     private lazy var untilTimeStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [untilTimeUnit, untilTime])
         stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = 10
+        return stackView
+    }()
+    
+    private lazy var timeZoneStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [fromTimeStackView, untilTimeStackView])
+        stackView.axis = .vertical
         stackView.alignment = .center
         stackView.spacing = 10
         return stackView
@@ -206,18 +226,31 @@ class ReportTimeZoneCell: UICollectionViewCell {
             make.leading.equalToSuperview().offset(25)
         }
         
-        view.addSubview(fromTimeStackView)
-        fromTimeStackView.snp.makeConstraints { make in
-            make.top.equalTo(subTitle.snp.bottom).offset(109)
-            make.leading.equalToSuperview().offset(25)
+        view.addSubview(subView)
+        subView.snp.makeConstraints { make in
+            make.top.equalTo(subTitle.snp.bottom)
+            make.leading.trailing.bottom.equalToSuperview()
         }
         
+        subView.addSubview(timeZoneView)
+        timeZoneView.snp.makeConstraints { make in
+            make.height.equalTo(190)
+            make.centerY.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
+        }
+        
+        timeZoneView.addSubview(fromTimeStackView)
+        fromTimeStackView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.leading.equalToSuperview().offset(25)
+        }
+
         view.addSubview(untilTimeStackView)
         untilTimeStackView.snp.makeConstraints { make in
             make.top.equalTo(fromTimeStackView.snp.bottom).offset(10)
             make.trailing.equalToSuperview().offset(-25)
         }
-        
+
         view.addSubview(fromTimeLine)
         fromTimeLine.snp.makeConstraints { make in
             make.height.equalTo(4)
@@ -225,7 +258,7 @@ class ReportTimeZoneCell: UICollectionViewCell {
             make.leading.equalTo(fromTimeStackView.snp.trailing).offset(10)
             make.trailing.equalToSuperview()
         }
-        
+
         view.addSubview(untilTimeLine)
         untilTimeLine.snp.makeConstraints { make in
             make.height.equalTo(4)

--- a/HWIBAL/Views/ReportView/ReportTimeZoneCell.swift
+++ b/HWIBAL/Views/ReportView/ReportTimeZoneCell.swift
@@ -27,6 +27,7 @@ class ReportTimeZoneCell: UICollectionViewCell {
         label.textColor = .black
         label.textAlignment = .left
         label.numberOfLines = 2
+        label.adjustsFontSizeToFitWidth = true
         return label
     }()
     
@@ -36,6 +37,7 @@ class ReportTimeZoneCell: UICollectionViewCell {
         label.textColor = .black
         label.textAlignment = .left
         label.numberOfLines = 2
+        label.adjustsFontSizeToFitWidth = true
         return label
     }()
     
@@ -96,18 +98,12 @@ class ReportTimeZoneCell: UICollectionViewCell {
     private lazy var fromTimeLine: UIView = {
         let view = UIView()
         view.backgroundColor = ColorGuide.main
-        view.snp.makeConstraints { make in
-            make.height.equalTo(4)
-        }
         return view
     }()
     
     private lazy var untilTimeLine: UIView = {
         let view = UIView()
         view.backgroundColor = ColorGuide.main
-        view.snp.makeConstraints { make in
-            make.height.equalTo(4)
-        }
         return view
     }()
     
@@ -224,6 +220,7 @@ class ReportTimeZoneCell: UICollectionViewCell {
         
         view.addSubview(fromTimeLine)
         fromTimeLine.snp.makeConstraints { make in
+            make.height.equalTo(4)
             make.top.equalTo(fromTimeStackView.snp.top).offset(46)
             make.leading.equalTo(fromTimeStackView.snp.trailing).offset(10)
             make.trailing.equalToSuperview()
@@ -231,6 +228,7 @@ class ReportTimeZoneCell: UICollectionViewCell {
         
         view.addSubview(untilTimeLine)
         untilTimeLine.snp.makeConstraints { make in
+            make.height.equalTo(4)
             make.top.equalTo(untilTimeStackView.snp.top).offset(45)
             make.leading.equalToSuperview()
             make.trailing.equalTo(untilTimeStackView.snp.leading).offset(-10)

--- a/HWIBAL/Views/ReportView/ReportView.swift
+++ b/HWIBAL/Views/ReportView/ReportView.swift
@@ -22,10 +22,6 @@ final class ReportView: UIView, RootView {
         button.titleLabel?.font = FontGuide.size14Bold
         button.backgroundColor = ColorGuide.subButton
         button.layer.cornerRadius = 14
-        button.snp.makeConstraints { make in
-            make.width.equalTo(78)
-            make.height.equalTo(28)
-        }
         return button
     }()
     
@@ -39,40 +35,32 @@ final class ReportView: UIView, RootView {
     
     lazy var numberOfPage: UILabel = {
         let label = UILabel()
-        
         let currentPageText = "\(currentPage) "
         let totalPageText = "/ 3"
-
         let attributedString = NSMutableAttributedString(string: currentPageText, attributes: [
             .font: FontGuide.size16Bold,
             .foregroundColor: UIColor.white
         ])
-
         let totalPageAttributedString = NSAttributedString(string: totalPageText, attributes: [
             .font: FontGuide.size16Bold,
             .foregroundColor: ColorGuide.textHint
         ])
-
         attributedString.append(totalPageAttributedString)
-        
         label.attributedText = attributedString
         label.textAlignment = .right
-        
         return label
     }()
     
     let collectionView: UICollectionView = {
         let layout = UICollectionViewCompositionalLayout { sectionIndex, layoutEnvironment in
-            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(538))
+            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.9))
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
             let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
             let section = NSCollectionLayoutSection(group: group)
             section.orthogonalScrollingBehavior = .none
-                
             return section
         }
-        
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .black
         collectionView.showsVerticalScrollIndicator = false
@@ -105,6 +93,8 @@ final class ReportView: UIView, RootView {
         
         addSubview(goToFirstButton)
         goToFirstButton.snp.makeConstraints { make in
+            make.width.equalTo(78)
+            make.height.equalTo(28)            
             make.top.equalTo(layoutMarginsGuide.snp.top).offset(24)
             make.trailing.equalToSuperview().offset(-25)
         }
@@ -135,19 +125,15 @@ final class ReportView: UIView, RootView {
     func updateNumberOfPageLabel(_ currentPage: Int) {
         let currentPageText = "\(currentPage) "
         let totalPageText = "/ 3"
-        
         let attributedString = NSMutableAttributedString(string: currentPageText, attributes: [
             .font: FontGuide.size16Bold,
             .foregroundColor: UIColor.white
         ])
-        
         let totalPageAttributedString = NSAttributedString(string: totalPageText, attributes: [
             .font: FontGuide.size16Bold,
             .foregroundColor: ColorGuide.textHint
         ])
-        
         attributedString.append(totalPageAttributedString)
-        
         numberOfPage.attributedText = attributedString
     }
 

--- a/HWIBAL/Views/Shared/MainButton.swift
+++ b/HWIBAL/Views/Shared/MainButton.swift
@@ -24,7 +24,6 @@ class MainButton: UIButton {
         layer.borderColor = customButtonType.borderColor.cgColor
         layer.borderWidth = customButtonType.borderWidth
         snp.makeConstraints { make in
-            make.width.equalTo(345)
             make.height.equalTo(56)
         }
     }


### PR DESCRIPTION
* 첫번째 셀: SE 시뮬레이션 빌드 시 데이터셋 값 짤리는 문제 해결
* 두번째 셀: 요일 양옆 마진 안맞는 문제 해결, center 정렬
`(콘솔창에 오토레이아웃 충돌 코드 뜨는 경우 -> Top3 요일이 없을 경우 뜨는 메세지로, 3개의 요일 이상 작성할 경우 오류 발생하지 않음)`
* 세번째 셀: SE 시뮬레이션 빌드 시 center 안맞는 문제 해결
* issue #72 #74 대응
<br>

**[SE]**
|                          첫번째 셀                          |                           두번째 셀                           |                           세번째 셀                           |
| :------------------------------------: | :------------------------------------: |:------------------------------------: |
| <img width="300" alt="image" src="https://github.com/hidaehyunlee/HWIBAL/assets/53863005/d7b744e1-6443-4dfb-be1a-3fa7e0e167ec"> | <img width="300" alt="image" src="https://github.com/hidaehyunlee/HWIBAL/assets/53863005/a9e199c4-8aab-402f-befc-04329bf0c4ed"> | <img width="300" alt="image" src="https://github.com/hidaehyunlee/HWIBAL/assets/53863005/fe3cf880-b0c0-409f-b633-449957fe4257"> |

<br>

**[14 Pro]**
|                          첫번째 셀                          |                           두번째 셀                           |                           세번째 셀                           |
| :------------------------------------: | :------------------------------------: |:------------------------------------: |
| <img width="300" alt="image" src="https://github.com/hidaehyunlee/HWIBAL/assets/53863005/be105bc2-73d0-4251-8674-4bd615ece72e"> | <img width="300" alt="image" src="https://github.com/hidaehyunlee/HWIBAL/assets/53863005/e98ab473-62be-4c09-9c93-b2cca7816fe2"> | <img width="300" alt="image" src="https://github.com/hidaehyunlee/HWIBAL/assets/53863005/87950a68-bc9d-4fd9-9f10-7df4318e06a2"> |