### PR TITLE
[FIX] : 🐛 키보드 제어 로직 수정 Issue #65

### DIFF
--- a/HWIBAL/Controllers/CreatePageViewController.swift
+++ b/HWIBAL/Controllers/CreatePageViewController.swift
@@ -15,21 +15,29 @@ class CreatePageViewController: RootViewController<CreatePageView>, AVAudioRecor
     var playButton: UIButton?
     var savedAudioURL: URL?
     private var audioPlayer: AVAudioPlayer?
+    private var activeTextView: UITextView?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
         setupNavigationBar()
+        hideKeyboard()
+        registerForKeyboardNotifications()
         view.backgroundColor = .systemBackground
         
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
-    
         rootView.soundButton.addTarget(self, action: #selector(startOrStopRecording), for: .touchUpInside)
 
         rootView.cameraButton.addTarget(self, action: #selector(presentImagePickerOptions), for: .touchUpInside)
         
         setupPlayButton()
+    }
+    
+    private func registerForKeyboardNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc func keyboardWillHide(_ notification: Notification) {
+        view.frame.origin.y = 0
     }
 
     private func setupPlayButton() {
@@ -121,20 +129,6 @@ class CreatePageViewController: RootViewController<CreatePageView>, AVAudioRecor
         imagePicker.sourceType = sourceType
         imagePicker.delegate = self
         present(imagePicker, animated: true)
-    }
-    
-    @objc func keyboardWillShow(notification: NSNotification) {
-        if let userInfo = notification.userInfo,
-           let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect
-        {
-            keyboardHeight = keyboardFrame.height
-            adjustLayoutForKeyboardState()
-        }
-    }
-    
-    @objc func keyboardWillHide(notification: NSNotification) {
-        keyboardHeight = 0
-        adjustLayoutForKeyboardState()
     }
     
     func adjustLayoutForKeyboardState() {
@@ -272,5 +266,11 @@ extension CreatePageViewController: UIImagePickerControllerDelegate, UINavigatio
             make.bottom.equalTo(rootView.counterLabel.snp.top).offset(-10)
         }
         rootView.isImageViewAttached = true
+    }
+}
+
+extension CreatePageViewController: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        activeTextView = textView
     }
 }

--- a/HWIBAL/Controllers/CreatePageViewController.swift
+++ b/HWIBAL/Controllers/CreatePageViewController.swift
@@ -20,8 +20,6 @@ class CreatePageViewController: RootViewController<CreatePageView>, AVAudioRecor
         super.viewDidLoad()
         
         setupNavigationBar()
-        hideKeyboard()
-        registerForKeyboardNotifications()
         view.backgroundColor = .systemBackground
         
         rootView.soundButton.addTarget(self, action: #selector(startOrStopRecording), for: .touchUpInside)
@@ -29,14 +27,6 @@ class CreatePageViewController: RootViewController<CreatePageView>, AVAudioRecor
         rootView.cameraButton.addTarget(self, action: #selector(presentImagePickerOptions), for: .touchUpInside)
         
         setupPlayButton()
-    }
-    
-    private func registerForKeyboardNotifications() {
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-    
-    @objc func keyboardWillHide(_ notification: Notification) {
-        view.frame.origin.y = 0
     }
 
     private func setupPlayButton() {

--- a/HWIBAL/Controllers/CreatePageViewController.swift
+++ b/HWIBAL/Controllers/CreatePageViewController.swift
@@ -15,7 +15,6 @@ class CreatePageViewController: RootViewController<CreatePageView>, AVAudioRecor
     var playButton: UIButton?
     var savedAudioURL: URL?
     private var audioPlayer: AVAudioPlayer?
-    private var activeTextView: UITextView?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -266,11 +265,5 @@ extension CreatePageViewController: UIImagePickerControllerDelegate, UINavigatio
             make.bottom.equalTo(rootView.counterLabel.snp.top).offset(-10)
         }
         rootView.isImageViewAttached = true
-    }
-}
-
-extension CreatePageViewController: UITextViewDelegate {
-    func textViewDidBeginEditing(_ textView: UITextView) {
-        activeTextView = textView
     }
 }

--- a/HWIBAL/Controllers/Shared/RootViewController.swift
+++ b/HWIBAL/Controllers/Shared/RootViewController.swift
@@ -18,6 +18,7 @@ class RootViewController<View: RootView>: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         rootView.initializeUI()
+        hideKeyboard()
     }
     
     func hideKeyboard() {

--- a/HWIBAL/Controllers/Shared/RootViewController.swift
+++ b/HWIBAL/Controllers/Shared/RootViewController.swift
@@ -19,4 +19,13 @@ class RootViewController<View: RootView>: UIViewController {
         super.viewDidLoad()
         rootView.initializeUI()
     }
+    
+    func hideKeyboard() {
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(RootViewController.dismissKeyboard))
+        view.addGestureRecognizer(tap)
+    }
+    
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
 }


### PR DESCRIPTION
* Create 키보드 제어 로직 추가
* 나머지 페이지에서는 키보드 제어가 필요없어 Create 페이지에만 적용함
* **키보드가 올라오면 텍스트뷰가 dateLabel 하단으로 다 차지하기 때문에 dateLabel 있는 부분을 클릭해야 키보드가 내려감**
* Issue #65 대응

| SE | XS(실기기) | 14 Pro |
|:--:|:--:|:--:|
|<img src="https://github.com/hidaehyunlee/HWIBAL/assets/53863005/af05621e-c908-4e8c-ab6d-6353bcab8f75">|<img src="https://github.com/hidaehyunlee/HWIBAL/assets/53863005/02e4a10c-1793-4a9d-b2e2-125e18f9977c" width=225>|<img src="https://github.com/hidaehyunlee/HWIBAL/assets/53863005/eb3ee450-112d-4df4-9bff-5660e3aca76f">|
