### PR TITLE
[FIX]: 🐛 DetailView SE 사이즈 대응위해 오토레이아웃 수정

### DIFF
--- a/HWIBAL/Views/DetailView/DetailView.swift
+++ b/HWIBAL/Views/DetailView/DetailView.swift
@@ -62,7 +62,7 @@ final class DetailView: UIView, RootView {
         layout.itemSize = CarouselConst.itemSize
         layout.minimumLineSpacing = CarouselConst.itemSpacing
         layout.minimumInteritemSpacing = 0
-        
+
         let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
         view.isScrollEnabled = true
         view.showsHorizontalScrollIndicator = false
@@ -82,6 +82,12 @@ final class DetailView: UIView, RootView {
     private lazy var audioView: UIView = {
         let view = UIView()
         view.backgroundColor = .clear
+        return view
+    }()
+    
+    private lazy var testView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .red
         return view
     }()
 
@@ -112,25 +118,46 @@ final class DetailView: UIView, RootView {
     func initializeUI() {
         backgroundColor = .systemBackground
 
-        addSubview(DetailComponents)
-        audioView.addSubview(playPauseButton)
         addSubview(deleteButton)
-
-        DetailComponents.snp.makeConstraints { make in
-            make.centerY.equalToSuperview()
-            make.leading.equalToSuperview().offset(43)
-            make.trailing.equalToSuperview().offset(-43)
-        }
-
-        playPauseButton.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().offset(-15)
-        }
-
         deleteButton.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.width.equalTo(UIScreen.main.bounds.width - 48)
             make.height.equalTo(56)
             make.bottom.equalToSuperview().offset(-40)
+        }
+
+        addSubview(testView)
+        testView.snp.makeConstraints { make in
+            make.top.equalTo(layoutMarginsGuide.snp.top)
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(deleteButton.snp.top)
+        }
+
+        testView.addSubview(goToFirstButton)
+        goToFirstButton.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(54)
+            make.top.equalToSuperview().offset(15)
+            make.height.equalTo(20)
+        }
+
+        testView.addSubview(numberOfPageLabel)
+        numberOfPageLabel.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-54)
+            make.top.equalToSuperview().offset(15)
+            make.height.equalTo(20)
+        }
+
+        testView.addSubview(collectionView)
+        collectionView.snp.makeConstraints { make in
+            make.top.equalTo(goToFirstButton.snp.bottom).offset(15)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(440)
+        }
+
+        testView.addSubview(playPauseButton)
+        playPauseButton.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-58)
+            make.size.equalTo(36)
         }
     }
 

--- a/HWIBAL/Views/DetailView/DetailView.swift
+++ b/HWIBAL/Views/DetailView/DetailView.swift
@@ -49,27 +49,21 @@ final class DetailView: UIView, RootView {
             numberOfPageLabel.textAlignment = .right
         }
     }
-    
+
     lazy var numberOfPageLabel: UILabel = {
         let label = UILabel()
 
         return label
     }()
 
-    private let collectionViewFlowLayout: UICollectionViewFlowLayout = {
+    lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
-
         layout.scrollDirection = .horizontal
         layout.itemSize = CarouselConst.itemSize
         layout.minimumLineSpacing = CarouselConst.itemSpacing
         layout.minimumInteritemSpacing = 0
-
-        return layout
-    }()
-
-    lazy var collectionView: UICollectionView = {
-        let view = UICollectionView(frame: .zero, collectionViewLayout: self.collectionViewFlowLayout)
-
+        
+        let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
         view.isScrollEnabled = true
         view.showsHorizontalScrollIndicator = false
         view.showsVerticalScrollIndicator = true
@@ -103,38 +97,29 @@ final class DetailView: UIView, RootView {
 
     lazy var deleteButton = MainButton(type: .delete)
 
+    private lazy var DetailComponents: UIStackView = {
+        let topStackView = UIStackView(arrangedSubviews: [goToFirstButton, numberOfPageLabel])
+        topStackView.axis = .horizontal
+        topStackView.spacing = 140
+
+        let stackView = UIStackView(arrangedSubviews: [topStackView, collectionView, audioView])
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = 15
+        return stackView
+    }()
+
     func initializeUI() {
         backgroundColor = .systemBackground
 
-        addSubview(goToFirstButton)
-        addSubview(numberOfPageLabel)
-        addSubview(collectionView)
-        addSubview(audioView)
+        addSubview(DetailComponents)
         audioView.addSubview(playPauseButton)
         addSubview(deleteButton)
 
-        collectionView.snp.makeConstraints { make in
-            make.height.equalTo(CarouselConst.itemSize.height)
-            make.top.equalToSuperview().offset(196) // 오토레이아웃 고민하기
-            make.leading.trailing.equalToSuperview()
-        }
-
-        goToFirstButton.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(54)
-            make.bottom.equalTo(collectionView.snp.top).offset(-15)
-        }
-
-        numberOfPageLabel.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().offset(-54)
-            make.bottom.equalTo(collectionView.snp.top).offset(-15)
-        }
-
-        audioView.snp.makeConstraints { make in
-            make.width.equalTo(307)
-            make.height.equalTo(40)
+        DetailComponents.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
             make.leading.equalToSuperview().offset(43)
             make.trailing.equalToSuperview().offset(-43)
-            make.top.equalTo(collectionView.snp.bottom).offset(20)
         }
 
         playPauseButton.snp.makeConstraints { make in
@@ -143,6 +128,8 @@ final class DetailView: UIView, RootView {
 
         deleteButton.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
+            make.width.equalTo(UIScreen.main.bounds.width - 48)
+            make.height.equalTo(56)
             make.bottom.equalToSuperview().offset(-40)
         }
     }

--- a/HWIBAL/Views/DetailView/DetailView.swift
+++ b/HWIBAL/Views/DetailView/DetailView.swift
@@ -84,12 +84,6 @@ final class DetailView: UIView, RootView {
         view.backgroundColor = .clear
         return view
     }()
-    
-    private lazy var testView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .red
-        return view
-    }()
 
     lazy var playPauseButton: UIButton = {
         let button = UIButton()
@@ -103,61 +97,56 @@ final class DetailView: UIView, RootView {
 
     lazy var deleteButton = MainButton(type: .delete)
 
-    private lazy var DetailComponents: UIStackView = {
-        let topStackView = UIStackView(arrangedSubviews: [goToFirstButton, numberOfPageLabel])
-        topStackView.axis = .horizontal
-        topStackView.spacing = 140
-
-        let stackView = UIStackView(arrangedSubviews: [topStackView, collectionView, audioView])
-        stackView.axis = .vertical
-        stackView.alignment = .center
-        stackView.spacing = 15
-        return stackView
+    private lazy var detailMainView: UIView = {
+        let view = UIView()
+        return view
     }()
 
     func initializeUI() {
         backgroundColor = .systemBackground
 
+        addSubview(detailMainView)
+        detailMainView.addSubview(goToFirstButton)
+        detailMainView.addSubview(numberOfPageLabel)
+        detailMainView.addSubview(collectionView)
+        detailMainView.addSubview(playPauseButton)
         addSubview(deleteButton)
-        deleteButton.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.width.equalTo(UIScreen.main.bounds.width - 48)
-            make.height.equalTo(56)
-            make.bottom.equalToSuperview().offset(-40)
-        }
 
-        addSubview(testView)
-        testView.snp.makeConstraints { make in
+        detailMainView.snp.makeConstraints { make in
             make.top.equalTo(layoutMarginsGuide.snp.top)
             make.leading.trailing.equalToSuperview()
             make.bottom.equalTo(deleteButton.snp.top)
         }
 
-        testView.addSubview(goToFirstButton)
         goToFirstButton.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(54)
-            make.top.equalToSuperview().offset(15)
+            make.top.equalToSuperview().offset(45)
             make.height.equalTo(20)
         }
 
-        testView.addSubview(numberOfPageLabel)
         numberOfPageLabel.snp.makeConstraints { make in
             make.trailing.equalToSuperview().offset(-54)
-            make.top.equalToSuperview().offset(15)
+            make.top.equalToSuperview().offset(45)
             make.height.equalTo(20)
         }
 
-        testView.addSubview(collectionView)
         collectionView.snp.makeConstraints { make in
             make.top.equalTo(goToFirstButton.snp.bottom).offset(15)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(440)
+            make.height.equalTo(CarouselConst.itemSize.height)
         }
 
-        testView.addSubview(playPauseButton)
         playPauseButton.snp.makeConstraints { make in
             make.trailing.equalToSuperview().offset(-58)
+            make.top.equalTo(collectionView.snp.bottom).offset(15)
             make.size.equalTo(36)
+        }
+
+        deleteButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.width.equalTo(UIScreen.main.bounds.width - 48)
+            make.height.equalTo(56)
+            make.bottom.equalToSuperview().offset(-40)
         }
     }
 
@@ -185,7 +174,7 @@ final class DetailView: UIView, RootView {
 // Carousel 애니메이션: itemSize, itemSpacing, insetX 정의
 extension DetailView {
     enum CarouselConst {
-        static let itemSize = CGSize(width: 307, height: 440)
+        static let itemSize = CGSize(width: 307 * UIScreen.main.bounds.width / 393, height: 440 * UIScreen.main.bounds.height / 852)
         static let itemSpacing = 24.0
 
         static var insetX: CGFloat {


### PR DESCRIPTION
<img width="850" alt="image" src="https://github.com/hidaehyunlee/HWIBAL/assets/37580034/d3ae164f-d1df-4345-b9b2-aded4f211031">

- `static let itemSize = CGSize(width: 307 * UIScreen.main.bounds.width / 393, height: 440 * UIScreen.main.bounds.height / 852)` 로 변경 
  - 기존(307 * 440)